### PR TITLE
Fixes broken --remove-path option

### DIFF
--- a/lib/copyright_header/parser.rb
+++ b/lib/copyright_header/parser.rb
@@ -180,7 +180,7 @@ module CopyrightHeader
       end
 
       if @options.has_key?(:remove_path)
-        @options[:add_path].split(File::PATH_SEPARATOR).each { |path| remove(path) }
+        @options[:remove_path].split(File::PATH_SEPARATOR).each { |path| remove(path) }
       end
     end
 


### PR DESCRIPTION
No longer use ':add_path' key for '--remove-path' lib/copyright-header/parser.rb:184 -- Previously trying to split the :add_path when it may not be supplied during license removal.

Prior to this change, the argument passed to --remove-path is essentially ignored, and the command will fail if --remove-path is suppled but --add-path is not.
