### PR TITLE
Added path separator to output path.

### DIFF
--- a/lib/copyright_header/parser.rb
+++ b/lib/copyright_header/parser.rb
@@ -252,7 +252,7 @@ module CopyrightHeader
         dir = "#{@options[:output_dir]}/#{File.dirname(file).gsub(/^\/+/, '')}"
         STDERR.puts "UPDATE #{file} [output-dir #{dir}]"
         FileUtils.mkpath dir unless File.directory?(dir)
-        output_path = @options[:output_dir] + file
+        output_path = @options[:output_dir] + "/" + file
         f =File.new(output_path, 'w')
         f.write(contents)
         f.close


### PR DESCRIPTION
It appears the output path does not include a separator and will fail to write the output file (since it will not create a directory that matches the output path).
