### PR TITLE
Remove 'SKIP <dir> not file' for directories from stderr output.

### DIFF
--- a/lib/copyright_header/parser.rb
+++ b/lib/copyright_header/parser.rb
@@ -209,6 +209,8 @@ module CopyrightHeader
               STDERR.puts "SKIP #{path}; excluded"
               next
             end
+          elsif File.directory?(path)
+            next
           else
             STDERR.puts "SKIP #{path}; not file"
             next


### PR DESCRIPTION
- too verbose.
