### PR TITLE
Allow using newer github-linguist version

### DIFF
--- a/copyright-header.gemspec
+++ b/copyright-header.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.extra_rdoc_files = ['README.md', 'LICENSE', 'AUTHORS', 'contrib/syntax.yml' ]
   s.require_paths = ["lib"]
-  s.add_dependency('github-linguist', '~> 2.6.7')
+  s.add_dependency('github-linguist', '~> 2.6')
 end


### PR DESCRIPTION
Older version can fail to install due to escape_utils 0.3.2
compilation error on newer rubies.