### PR TITLE
Add Groovy syntax support

### DIFF
--- a/contrib/syntax.yml
+++ b/contrib/syntax.yml
@@ -76,6 +76,13 @@ java:
     close:  ' */\n\n'
     prefix: ' * '
 
+groovy:
+  ext: ['.groovy']
+  comment:
+    open:   '/*\n'
+    close:  ' */\n\n'
+    prefix: ' * '
+
 haml:
   ext: ['.haml', '.hamlc']
   comment:


### PR DESCRIPTION
Added Groovy syntax support in `contrib/syntax.yml`.

I'm not experienced with Ruby and don't know if there's a way to test this works, but it should. I've used a very similar syntax file to generate copyright headers for Groovy source files in my personal projects.

This is also the first fork/pull request I've done, so hopefully I haven't done anything silly.