### PR TITLE
update dependency to github-linguist

### DIFF
--- a/copyright-header.gemspec
+++ b/copyright-header.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.extra_rdoc_files = ['README.md', 'LICENSE', 'AUTHORS', 'contrib/syntax.yml' ]
   s.require_paths = ["lib"]
-  s.add_dependency('github-linguist', '~> 2.6')
+  s.add_dependency('github-linguist')
 end


### PR DESCRIPTION
This simple PR contains just the adjustment of the gemspec file. When integrating the gem into a new Rails application, some dependency issues occur because of the old github-linguist version. 