### PR TITLE
Adding support for React JSX files

### DIFF
--- a/contrib/syntax.yml
+++ b/contrib/syntax.yml
@@ -61,7 +61,7 @@ php:
     prefix: ' * '
 
 javacript:
-  ext: ['.js']
+  ext: ['.js', '.jsx']
   comment:
     open:   '/*\n'
     close:  ' */\n\n'


### PR DESCRIPTION
JSX files are simple javascript files with some html templates in them. It is safe to add copyright-header in them like any javascript file.