### PR TITLE
Don't add a header to empty files

### DIFF
--- a/copyright-header.gemspec
+++ b/copyright-header.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.extra_rdoc_files = ['README.md', 'LICENSE', 'AUTHORS', 'contrib/syntax.yml' ]
   s.require_paths = ["lib"]
-  s.add_runtime_dependency('github-linguist','~>6.0')
+  s.add_runtime_dependency('github-linguist','~>7.2')
 end

--- a/lib/copyright_header/parser.rb
+++ b/lib/copyright_header/parser.rb
@@ -26,6 +26,7 @@ require 'linguist'
 module CopyrightHeader
   class FileNotFoundException < Exception; end
   class ExistingLicenseException < Exception; end
+  class EmptyFileException < Exception; end
 
   class License
     @lines = []
@@ -84,6 +85,10 @@ module CopyrightHeader
       if copyright.nil?
         STDERR.puts "Copyright is nil"
         return nil
+      end
+
+      if @contents.strip.empty?
+        raise EmptyFileException.new("file is empty")
       end
 
       text = ""


### PR DESCRIPTION
Python requires package folders to have an '__init__.py' file, but usually this file is empty.
Since there is no code in the file adding a copyright header seemed to me to be a bit nonsensical.
I suppose this could be a flag, but I really can't think of why anyone should need a copyright header for an empty file?